### PR TITLE
Fix KUBERNETES_CSI_OWNERS_ALIASES file for emeritus_approver and emer…

### DIFF
--- a/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
@@ -31,15 +31,15 @@ aliases:
 
 # This documents who previously contributed to Kubernetes-CSI
 # as approver.
-emeritus_approver:
+emeritus_approvers:
 - lpabon
 - sbezverk
 - vladimirvivien
 
 # This documents who previously contributed to Kubernetes-CSI
 # as reviewer.
-emeritus_reviewer:
-- lpabon
-- saad-ali
-- sbezverk
-- vladimirvivien
+# emeritus_reviewer:
+# - lpabon
+# - saad-ali
+# - sbezverk
+# - vladimirvivien


### PR DESCRIPTION
Fix KUBERNETES_CSI_OWNERS_ALIASES file for emeritus_approver and emeritus_reviewer

Change emeritus_approver to emeritus_approvers and remove emeritus_reviewer

Signed-off-by: Srinivas Pokala <Pokala.Srinivas@ibm.com>

**What this PR does / why we need it:**
This PR fixes the KUBERNETES_CSI_OWNERS_ALIASES file

**What type of PR is this?**
/kind cleanup

**Which issue(s) this PR fixes:**

Fixes #https://github.com/kubernetes/community/issues/6334